### PR TITLE
use SPDX license id in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     }
   ],
   "author": "mikaoelitiana",
-  "license": "BSD-3",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/mikaoelitiana/cordova-ios-plugin-no-export-compliance/issues"
   },


### PR DESCRIPTION
The license field in the package.json should contain an SPDX license id (https://docs.npmjs.com/files/package.json#license).

The one in here isn't quiet right according to https://spdx.org/licenses/. This breaks our rather strict-matching license check.
I hope this variant of BSD-3 is the one you want - there is quiet a lot of them.

Thanks!